### PR TITLE
Infn feedback v2

### DIFF
--- a/message-monitoring/Dashboards/Rucio-Transfer.json
+++ b/message-monitoring/Dashboards/Rucio-Transfer.json
@@ -688,7 +688,7 @@
                 "type": "count"
               }
             ],
-            "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+            "query": "event_type:transfer-failed AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
             "refId": "A",
             "timeField": "created_at"
           }
@@ -2415,7 +2415,7 @@
         },
         {
           "current": {
-            "selected": false,
+            "selected": true,
             "text": "payload.dst-rse",
             "value": "payload.dst-rse"
           },

--- a/message-monitoring/Dashboards/Rucio-Transfer.json
+++ b/message-monitoring/Dashboards/Rucio-Transfer.json
@@ -1,2598 +1,2597 @@
 {
-  "metadata": {
-    "name": "rucio-transfer",
-    "annotations": {
-       "grafana.app/folder": "folderuid"
+ "metadata": {
+   "name": "rucio-transfer",
+   "annotations": {
+      "grafana.app/folder": "folderuid"
+   }
+ },
+ "spec": {
+  "__inputs": [
+    {
+      "name": "elasticsearch",
+      "label": "Rucio",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "elasticsearch",
+      "pluginName": "Elasticsearch"
     }
-  },
-  "spec": {
-    "__inputs": [
+  ],
+  "annotations": {
+    "list": [
       {
-        "name": "elasticsearch",
-        "label": "Rucio",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "elasticsearch",
-        "pluginName": "Elasticsearch"
-      }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
           "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 41,
-    "links": [],
-    "liveNow": false,
-    "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
         },
-        "id": 5,
-        "panels": [],
-        "title": "Transfer-done",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "description": "Number of transfers reported as done from the 1st query, and the number of failed transfers from the second query",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "axisSoftMin": 0,
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 6,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "always",
-              "spanNulls": true,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "percent"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 1
-        },
-        "id": 24,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list",
-            "placement": "right",
-            "showLegend": true
-          },
-          "tooltip": {
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-      "pluginVersion": "12.2.0",
-        "targets": [
-          {
-            "alias": "Success",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "4",
-                "settings": {
-                  "min_doc_count": "0",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "0"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "3",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "hide": true,
-            "metrics": [
-              {
-                "id": "1",
-                "type": "count"
-              }
-            ],
-            "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          },
-          {
-            "alias": "Total",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "4",
-                "settings": {
-                  "min_doc_count": "0",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "0"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "3",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "hide": true,
-            "metrics": [
-              {
-                "id": "1",
-                "type": "count"
-              }
-            ],
-            "query": "(event_type:transfer-done OR event_type:transfer-failed) AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "B",
-            "timeField": "created_at"
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "($A / $B) * 100",
-            "hide": false,
-            "refId": "‎",
-            "type": "math"
-          }
-        ],
-        "title": "Efficiency",
-        "transparent": true,
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "description": "Rough data transfer speeds are calculated from the bytes of the files summed over the time bin, divided by the duration (summed over the time bin) reported. \n\nThe binning is locked to 1 hour, as making it adaptive breaks the query.\n\nThe issue is that FTS, the one used here, reports 2 durations as the duration of the FTS event. In contrast, inside the logging there is the duration of only the transfer - This should be negligible for larger files, but may report lower rates for smaller files.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineWidth": 2,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "Bps"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 1
-        },
-        "id": 23,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "table",
-            "placement": "right",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "3",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "2",
-                "settings": {
-                  "interval": "1h"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "hide": true,
-            "metrics": [
-              {
-                "field": "payload.bytes",
-                "id": "1",
-                "type": "sum"
-              }
-            ],
-            "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          },
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "3",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "2",
-                "settings": {
-                  "interval": "1h"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "hide": true,
-            "metrics": [
-              {
-                "field": "payload.duration",
-                "id": "1",
-                "type": "sum"
-              }
-            ],
-            "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} and payload.transfer-endpoint:${fts:lucene}",
-            "refId": "B",
-            "timeField": "created_at"
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$A / $B",
-            "hide": false,
-            "refId": "‎",
-            "type": "math"
-          }
-        ],
-        "title": "Transfer Throughput",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {}
-          }
-        ],
-        "transparent": true,
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "description": "Count of transfers that are labelled a done, and can be grouped by the Group by variable",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineStyle": {
-                "fill": "solid"
-              },
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 6,
-          "x": 0,
-          "y": 9
-        },
-        "id": 25,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "table",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "2",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "0"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "3",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "metrics": [
-              {
-                "id": "1",
-                "type": "count"
-              }
-            ],
-            "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Transfer Successes",
-        "transparent": true,
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "description": "Count of transfers that are labelled a failed, and can be grouped by the Group by variable",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineStyle": {
-                "fill": "solid"
-              },
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "short"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "transfer-failed"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "dark-red",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 6,
-          "x": 6,
-          "y": 9
-        },
-        "id": 26,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "table",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "2",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "0"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "3",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "metrics": [
-              {
-                "id": "1",
-                "type": "count"
-              }
-            ],
-            "query": "event_type:transfer-failed AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Transfer Failures",
-        "transparent": true,
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "description": "Sum of the bytes over the binned time, grouped by the group by variable",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineStyle": {
-                "fill": "solid"
-              },
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 9
-        },
-        "id": 2,
-        "options": {
-          "legend": {
-            "calcs": [
-              "mean",
-              "max",
-              "sum"
-            ],
-            "displayMode": "table",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "2",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "3",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "metrics": [
-              {
-                "field": "payload.bytes",
-                "id": "1",
-                "type": "sum"
-              }
-            ],
-            "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Data moved",
-        "transparent": true,
-        "type": "timeseries"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 17
-        },
-        "id": 29,
-        "panels": [],
-        "title": "Deletions",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "description": "Grouped by payload.rse as this is different for deletions and transfers",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineStyle": {
-                "fill": "solid"
-              },
-              "lineWidth": 0,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "none"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 12,
-          "x": 0,
-          "y": 18
-        },
-        "id": 27,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "table",
-            "placement": "right",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-      "pluginVersion": "12.2.0",
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "payload.rse",
-                "id": "3",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "4",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "hide": false,
-            "metrics": [
-              {
-                "id": "1",
-                "type": "count"
-              }
-            ],
-            "query": "event_type:deletion-done AND payload.rse:${del_rse:lucene} AND payload.protocol:${protocol:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Deletions",
-        "transparent": true,
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "description": "Grouped by payload.rse as this is different for deletions and transfers",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineStyle": {
-                "fill": "solid"
-              },
-              "lineWidth": 0,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "never",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "Bps"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 12,
-          "x": 12,
-          "y": 18
-        },
-        "id": 30,
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "table",
-            "placement": "right",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "multi",
-            "sort": "none"
-          }
-        },
-      "pluginVersion": "12.2.0",
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "payload.rse",
-                "id": "3",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "4",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "hide": true,
-            "metrics": [
-              {
-                "field": "payload.bytes",
-                "id": "1",
-                "type": "sum"
-              }
-            ],
-            "query": "event_type:deletion-done",
-            "refId": "A",
-            "timeField": "created_at"
-          },
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "payload.rse",
-                "id": "3",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "4",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "hide": true,
-            "metrics": [
-              {
-                "field": "payload.duration",
-                "id": "1",
-                "type": "sum"
-              }
-            ],
-            "query": "event_type:deletion-done\n\n",
-            "refId": "B",
-            "timeField": "created_at"
-          },
-          {
-            "datasource": {
-              "name": "Expression",
-              "type": "__expr__",
-              "uid": "__expr__"
-            },
-            "expression": "$A / $B\n",
-            "hide": false,
-            "refId": "‎ ",
-            "type": "math"
-          }
-        ],
-        "title": "Deletions Rate",
-        "transparent": true,
-        "type": "timeseries"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 28
-        },
-        "id": 18,
-        "panels": [],
-        "title": "Transfer Errors",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "auto"
-              },
-              "filterable": false,
-              "inspect": true
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.reason"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 1311
-                },
-                {
-                  "id": "displayName",
-                  "value": "Failure Reason"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Failure Reason"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 887
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 7,
-          "w": 24,
-          "x": 0,
-          "y": 29
-        },
-        "id": 21,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "enablePagination": false,
-            "fields": [],
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": [
-            {
-              "desc": true,
-              "displayName": "Count"
-            }
-          ]
-        },
-      "pluginVersion": "12.2.0",
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "payload.reason",
-                "id": "2",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "metrics": [
-              {
-                "id": "1",
-                "type": "count"
-              }
-            ],
-            "query": "event_type:transfer-failed",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Transfer Failed Error Reasons",
-        "transparent": true,
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "auto"
-              },
-              "inspect": false
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.duration"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 100
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "created_at"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 156
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.account"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 122
-                },
-                {
-                  "id": "displayName",
-                  "value": "Account"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.activity"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 122
-                },
-                {
-                  "id": "displayName",
-                  "value": "Activity"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.dataset"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 123
-                },
-                {
-                  "id": "displayName",
-                  "value": "Dataset"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.datasetScope"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 157
-                },
-                {
-                  "id": "displayName",
-                  "value": "DatasetScope"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.dst-rse"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 124
-                },
-                {
-                  "id": "displayName",
-                  "value": "dst RSE"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.dst-url"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 124
-                },
-                {
-                  "id": "displayName",
-                  "value": "dst URL"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.protocol"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 74
-                },
-                {
-                  "id": "displayName",
-                  "value": "Protocol"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.duration"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Duration"
-                },
-                {
-                  "id": "custom.width",
-                  "value": 50
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.reason"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Reason"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.src-rse"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "src RSE"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.src-url"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "src URL"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.started_at"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Started at"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.submitted_at"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Submitted at"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transfer-endpoint"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "FTS"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transfer-id"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "FTS ID"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transfer_link"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "FTS log link"
-                },
-                {
-                  "id": "links",
-                  "value": [
-                    {
-                      "targetBlank": true,
-                      "title": "",
-                      "url": "${__value.raw}"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transferred_at"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Transferred at"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Transferred at"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 153
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Duration"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 71
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 24,
-          "x": 0,
-          "y": 36
-        },
-        "id": 14,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": [
-            {
-              "desc": false,
-              "displayName": "src RSE"
-            }
-          ]
-        },
-      "pluginVersion": "12.2.0",
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "id": "1",
-                "settings": {
-                  "interval": "auto"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "metrics": [
-              {
-                "id": "1",
-                "type": "logs"
-              }
-            ],
-            "query": "event_type:transfer-failed AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Transfer Failure information",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "_id": true,
-                "_index": true,
-                "_source": true,
-                "_type": true,
-                "created_at": false,
-                "event_type": true,
-                "highlight": true,
-                "id": true,
-                "payload.bytes": true,
-                "payload.checksum-adler": true,
-                "payload.checksum-md5": true,
-                "payload.created_at": true,
-                "payload.dataset": false,
-                "payload.datatype": true,
-                "payload.dst-rse": false,
-                "payload.dst-type": true,
-                "payload.dst-url": false,
-                "payload.file-size": true,
-                "payload.guid": true,
-                "payload.previous-request-id": true,
-                "payload.request-id": true,
-                "payload.scope": true,
-                "payload.src-type": true,
-                "payload.started_at": false,
-                "payload.tool-id": true,
-                "payload.transfer-endpoint": false,
-                "payload.transfer-link": true,
-                "services": true,
-                "sort": true
-              },
-              "indexByName": {
-                "_id": 1,
-                "_index": 2,
-                "_source": 3,
-                "_type": 4,
-                "created_at": 0,
-                "event_type": 5,
-                "highlight": 6,
-                "id": 7,
-                "payload.account": 8,
-                "payload.activity": 9,
-                "payload.bytes": 10,
-                "payload.checksum-adler": 11,
-                "payload.checksum-md5": 12,
-                "payload.created_at": 13,
-                "payload.dataset": 15,
-                "payload.datasetScope": 16,
-                "payload.datatype": 18,
-                "payload.dst-rse": 20,
-                "payload.dst-type": 21,
-                "payload.dst-url": 42,
-                "payload.duration": 40,
-                "payload.file-size": 23,
-                "payload.guid": 24,
-                "payload.name": 14,
-                "payload.previous-request-id": 25,
-                "payload.protocol": 17,
-                "payload.reason": 26,
-                "payload.request-id": 27,
-                "payload.scope": 28,
-                "payload.src-rse": 19,
-                "payload.src-type": 29,
-                "payload.src-url": 41,
-                "payload.started_at": 30,
-                "payload.submitted_at": 31,
-                "payload.tool-id": 32,
-                "payload.transfer-endpoint": 33,
-                "payload.transfer-id": 34,
-                "payload.transfer-link": 35,
-                "payload.transfer_link": 22,
-                "payload.transferred_at": 36,
-                "services": 38,
-                "sort": 39
-              },
-              "renameByName": {}
-            }
-          }
-        ],
-        "transparent": true,
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "auto"
-              },
-              "inspect": false
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.duration"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 100
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "created_at"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 156
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.account"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 122
-                },
-                {
-                  "id": "displayName",
-                  "value": "Account"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.activity"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 122
-                },
-                {
-                  "id": "displayName",
-                  "value": "Activity"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.dataset"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 123
-                },
-                {
-                  "id": "displayName",
-                  "value": "Dataset"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.datasetScope"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 157
-                },
-                {
-                  "id": "displayName",
-                  "value": "DatasetScope"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.dst-rse"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 124
-                },
-                {
-                  "id": "displayName",
-                  "value": "dst RSE"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.dst-url"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 124
-                },
-                {
-                  "id": "displayName",
-                  "value": "dst URL"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.protocol"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 74
-                },
-                {
-                  "id": "displayName",
-                  "value": "Protocol"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.duration"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Duration"
-                },
-                {
-                  "id": "custom.width",
-                  "value": 50
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.reason"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Reason"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.src-rse"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "src RSE"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.src-url"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "src URL"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.started_at"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Started at"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.submitted_at"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Submitted at"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transfer-endpoint"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "FTS"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transfer-id"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "FTS ID"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transfer_link"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "FTS log link"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "payload.transferred_at"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Transferred at"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Transferred at"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 153
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Duration"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 71
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 24,
-          "x": 0,
-          "y": 44
-        },
-        "id": 19,
-        "options": {
-          "cellHeight": "sm",
-          "footer": {
-            "countRows": false,
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": []
-        },
-      "pluginVersion": "12.2.0",
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "metrics": [
-              {
-                "id": "1",
-                "settings": {
-                  "order": "desc",
-                  "size": "500",
-                  "useTimeRange": true
-                },
-                "type": "raw_data"
-              }
-            ],
-            "query": "event_type:transfer-submission_failed",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Transfer Submission Failure information",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "_id": true,
-                "_index": true,
-                "_source": true,
-                "_type": true,
-                "created_at": false,
-                "event_type": true,
-                "highlight": true,
-                "id": true,
-                "payload.bytes": true,
-                "payload.checksum-adler": true,
-                "payload.checksum-md5": true,
-                "payload.created_at": true,
-                "payload.datatype": true,
-                "payload.dst-rse": false,
-                "payload.dst-type": true,
-                "payload.file-size": true,
-                "payload.guid": true,
-                "payload.previous-request-id": true,
-                "payload.request-id": true,
-                "payload.scope": true,
-                "payload.src-type": true,
-                "payload.started_at": false,
-                "payload.tool-id": true,
-                "payload.transfer-endpoint": false,
-                "payload.transfer-link": true,
-                "services": true,
-                "sort": true
-              },
-              "indexByName": {},
-              "renameByName": {}
-            }
-          }
-        ],
-        "transparent": true,
-        "type": "table"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 52
-        },
-        "id": 9,
-        "panels": [],
-        "title": "Transfer-submitted",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "elasticsearch",
-          "uid": "${elasticsearch}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisBorderShow": false,
-              "axisCenteredZero": false,
-              "axisColorMode": "text",
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "insertNulls": false,
-              "lineInterpolation": "linear",
-              "lineStyle": {
-                "fill": "solid"
-              },
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "normal"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "bytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 24,
-          "x": 0,
-          "y": 53
-        },
-        "id": 6,
-        "options": {
-          "legend": {
-            "calcs": [
-              "mean",
-              "max",
-              "sum"
-            ],
-            "displayMode": "table",
-            "placement": "bottom",
-            "showLegend": true
-          },
-          "tooltip": {
-            "maxHeight": 600,
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "alias": "",
-            "bucketAggs": [
-              {
-                "field": "$group_by",
-                "id": "2",
-                "settings": {
-                  "min_doc_count": "1",
-                  "order": "desc",
-                  "orderBy": "_term",
-                  "size": "10"
-                },
-                "type": "terms"
-              },
-              {
-                "field": "created_at",
-                "id": "3",
-                "settings": {
-                  "interval": "$bin",
-                  "min_doc_count": "0",
-                  "timeZone": "utc",
-                  "trimEdges": "0"
-                },
-                "type": "date_histogram"
-              }
-            ],
-            "datasource": {
-              "type": "elasticsearch",
-              "uid": "${elasticsearch}"
-            },
-            "metrics": [
-              {
-                "field": "payload.bytes",
-                "id": "1",
-                "type": "sum"
-              }
-            ],
-            "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
-            "refId": "A",
-            "timeField": "created_at"
-          }
-        ],
-        "title": "Transfer-submitted by $group_by",
-        "type": "timeseries"
+        "type": "dashboard"
       }
-    ],
-    "refresh": "1m",
-    "schemaVersion": 39,
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Transfer-done",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "description": "Number of transfers reported as done from the 1st query, and the number of failed transfers from the second query",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
             ]
           },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+    "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "alias": "Success",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "4",
+              "settings": {
+                "min_doc_count": "0",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "0"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "3",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
           "datasource": {
             "type": "elasticsearch",
             "uid": "${elasticsearch}"
           },
-          "definition": "{\"find\": \"terms\", \"field\": \"payload.transfer-endpoint\"}",
-          "hide": 0,
-          "includeAll": true,
-          "label": "FTS Server",
-          "multi": true,
-          "name": "fts",
-          "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"payload.transfer-endpoint\"}",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+          "hide": true,
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
         },
         {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
+          "alias": "Total",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "4",
+              "settings": {
+                "min_doc_count": "0",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "0"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "3",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "hide": true,
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "(event_type:transfer-done OR event_type:transfer-failed) AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "B",
+          "timeField": "created_at"
+        },
+        {
+          "datasource": {
+            "name": "Expression",
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "($A / $B) * 100",
+          "hide": false,
+          "refId": "‎",
+          "type": "math"
+        }
+      ],
+      "title": "Efficiency",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "description": "Rough data transfer speeds are calculated from the bytes of the files summed over the time bin, divided by the duration (summed over the time bin) reported. \n\nThe binning is locked to 1 hour, as making it adaptive breaks the query.\n\nThe issue is that FTS, the one used here, reports 2 durations as the duration of the FTS event. In contrast, inside the logging there is the duration of only the transfer - This should be negligible for larger files, but may report lower rates for smaller files.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
             ]
           },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "3",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "2",
+              "settings": {
+                "interval": "1h"
+              },
+              "type": "date_histogram"
+            }
+          ],
           "datasource": {
             "type": "elasticsearch",
             "uid": "${elasticsearch}"
           },
-          "definition": "{\"find\":  \"terms\", \"field\": \"payload.dst-rse\"} ",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Dest Site",
-          "multi": true,
-          "name": "dst_rse",
-          "options": [],
-          "query": "{\"find\":  \"terms\", \"field\": \"payload.dst-rse\"} ",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+          "hide": true,
+          "metrics": [
+            {
+              "field": "payload.bytes",
+              "id": "1",
+              "type": "sum"
+            }
+          ],
+          "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
         },
         {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "3",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "2",
+              "settings": {
+                "interval": "1h"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "hide": true,
+          "metrics": [
+            {
+              "field": "payload.duration",
+              "id": "1",
+              "type": "sum"
+            }
+          ],
+          "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} and payload.transfer-endpoint:${fts:lucene}",
+          "refId": "B",
+          "timeField": "created_at"
+        },
+        {
+          "datasource": {
+            "name": "Expression",
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A / $B",
+          "hide": false,
+          "refId": "‎",
+          "type": "math"
+        }
+      ],
+      "title": "Transfer Throughput",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {}
+        }
+      ],
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "description": "Count of transfers that are labelled a done, and can be grouped by the Group by variable",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
             ]
           },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "2",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "0"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "3",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
           "datasource": {
             "type": "elasticsearch",
             "uid": "${elasticsearch}"
           },
-          "definition": "{\"find\":  \"terms\", \"field\": \"payload.src-rse\"} ",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Source Site",
-          "multi": true,
-          "name": "src_rse",
-          "options": [],
-          "query": "{\"find\":  \"terms\", \"field\": \"payload.src-rse\"} ",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": true,
-            "text": "payload.dst-rse",
-            "value": "payload.dst-rse"
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Transfer Successes",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "description": "Count of transfers that are labelled a failed, and can be grouped by the Group by variable",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
           },
-          "datasource": {
-            "type": "elasticsearch",
-            "uid": "${elasticsearch}"
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
-          "definition": "{\"find\": \"fields\", \"type\": \"keyword\"}",
-          "hide": 0,
-          "includeAll": false,
-          "label": "Group By",
-          "multi": false,
-          "name": "group_by",
-          "options": [],
-          "query": "{\"find\": \"fields\", \"type\": \"keyword\"}",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
             ]
           },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "transfer-failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "2",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "0"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "3",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
           "datasource": {
             "type": "elasticsearch",
             "uid": "${elasticsearch}"
           },
-          "definition": "{\"find\": \"terms\", \"field\": \"payload.protocol\"}",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Protocol",
-          "multi": true,
-          "name": "protocol",
-          "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"payload.protocol\"}",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "event_type:transfer-failed AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Transfer Failures",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "description": "Sum of the bytes over the binned time, grouped by the group by variable",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
         {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "2",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "3",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
           "datasource": {
             "type": "elasticsearch",
             "uid": "${elasticsearch}"
           },
-          "filters": [],
-          "hide": 0,
-          "label": "Filters",
-          "name": "filters",
-          "skipUrlSync": false,
-          "type": "adhoc"
+          "metrics": [
+            {
+              "field": "payload.bytes",
+              "id": "1",
+              "type": "sum"
+            }
+          ],
+          "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Data moved",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 29,
+      "panels": [],
+      "title": "Deletions",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "description": "Grouped by payload.rse as this is different for deletions and transfers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+    "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "payload.rse",
+              "id": "3",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "4",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "hide": false,
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "event_type:deletion-done AND payload.rse:${del_rse:lucene} AND payload.protocol:${protocol:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Deletions",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "description": "Grouped by payload.rse as this is different for deletions and transfers",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+    "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "payload.rse",
+              "id": "3",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "4",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "hide": true,
+          "metrics": [
+            {
+              "field": "payload.bytes",
+              "id": "1",
+              "type": "sum"
+            }
+          ],
+          "query": "event_type:deletion-done",
+          "refId": "A",
+          "timeField": "created_at"
         },
         {
-          "auto": true,
-          "auto_count": 20,
-          "auto_min": "10s",
-          "current": {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "payload.rse",
+              "id": "3",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "4",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "hide": true,
+          "metrics": [
+            {
+              "field": "payload.duration",
+              "id": "1",
+              "type": "sum"
+            }
+          ],
+          "query": "event_type:deletion-done\n\n",
+          "refId": "B",
+          "timeField": "created_at"
+        },
+        {
+          "datasource": {
+            "name": "Expression",
+            "type": "__expr__",
+            "uid": "__expr__"
+          },
+          "expression": "$A / $B\n",
+          "hide": false,
+          "refId": "‎ ",
+          "type": "math"
+        }
+      ],
+      "title": "Deletions Rate",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Transfer Errors",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false,
+            "inspect": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.reason"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 1311
+              },
+              {
+                "id": "displayName",
+                "value": "Failure Reason"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failure Reason"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 887
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 21,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": [],
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Count"
+          }
+        ]
+      },
+    "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "payload.reason",
+              "id": "2",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "query": "event_type:transfer-failed",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Transfer Failed Error Reasons",
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.duration"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "created_at"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.account"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 122
+              },
+              {
+                "id": "displayName",
+                "value": "Account"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.activity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 122
+              },
+              {
+                "id": "displayName",
+                "value": "Activity"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.dataset"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 123
+              },
+              {
+                "id": "displayName",
+                "value": "Dataset"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.datasetScope"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 157
+              },
+              {
+                "id": "displayName",
+                "value": "DatasetScope"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.dst-rse"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 124
+              },
+              {
+                "id": "displayName",
+                "value": "dst RSE"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.dst-url"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 124
+              },
+              {
+                "id": "displayName",
+                "value": "dst URL"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.protocol"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 74
+              },
+              {
+                "id": "displayName",
+                "value": "Protocol"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.duration"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Duration"
+              },
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.reason"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Reason"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.src-rse"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "src RSE"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.src-url"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "src URL"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.started_at"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Started at"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.submitted_at"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Submitted at"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transfer-endpoint"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FTS"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transfer-id"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FTS ID"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transfer_link"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FTS log link"
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "",
+                    "url": "${__value.raw}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transferred_at"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Transferred at"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Transferred at"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 153
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 71
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 14,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "src RSE"
+          }
+        ]
+      },
+    "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "id": "1",
+              "settings": {
+                "interval": "auto"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "type": "logs"
+            }
+          ],
+          "query": "event_type:transfer-failed AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Transfer Failure information",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "_id": true,
+              "_index": true,
+              "_source": true,
+              "_type": true,
+              "created_at": false,
+              "event_type": true,
+              "highlight": true,
+              "id": true,
+              "payload.bytes": true,
+              "payload.checksum-adler": true,
+              "payload.checksum-md5": true,
+              "payload.created_at": true,
+              "payload.dataset": false,
+              "payload.datatype": true,
+              "payload.dst-rse": false,
+              "payload.dst-type": true,
+              "payload.dst-url": false,
+              "payload.file-size": true,
+              "payload.guid": true,
+              "payload.previous-request-id": true,
+              "payload.request-id": true,
+              "payload.scope": true,
+              "payload.src-type": true,
+              "payload.started_at": false,
+              "payload.tool-id": true,
+              "payload.transfer-endpoint": false,
+              "payload.transfer-link": true,
+              "services": true,
+              "sort": true
+            },
+            "indexByName": {
+              "_id": 1,
+              "_index": 2,
+              "_source": 3,
+              "_type": 4,
+              "created_at": 0,
+              "event_type": 5,
+              "highlight": 6,
+              "id": 7,
+              "payload.account": 8,
+              "payload.activity": 9,
+              "payload.bytes": 10,
+              "payload.checksum-adler": 11,
+              "payload.checksum-md5": 12,
+              "payload.created_at": 13,
+              "payload.dataset": 15,
+              "payload.datasetScope": 16,
+              "payload.datatype": 18,
+              "payload.dst-rse": 20,
+              "payload.dst-type": 21,
+              "payload.dst-url": 42,
+              "payload.duration": 40,
+              "payload.file-size": 23,
+              "payload.guid": 24,
+              "payload.name": 14,
+              "payload.previous-request-id": 25,
+              "payload.protocol": 17,
+              "payload.reason": 26,
+              "payload.request-id": 27,
+              "payload.scope": 28,
+              "payload.src-rse": 19,
+              "payload.src-type": 29,
+              "payload.src-url": 41,
+              "payload.started_at": 30,
+              "payload.submitted_at": 31,
+              "payload.tool-id": 32,
+              "payload.transfer-endpoint": 33,
+              "payload.transfer-id": 34,
+              "payload.transfer-link": 35,
+              "payload.transfer_link": 22,
+              "payload.transferred_at": 36,
+              "services": 38,
+              "sort": 39
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.duration"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "created_at"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.account"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 122
+              },
+              {
+                "id": "displayName",
+                "value": "Account"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.activity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 122
+              },
+              {
+                "id": "displayName",
+                "value": "Activity"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.dataset"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 123
+              },
+              {
+                "id": "displayName",
+                "value": "Dataset"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.datasetScope"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 157
+              },
+              {
+                "id": "displayName",
+                "value": "DatasetScope"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.dst-rse"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 124
+              },
+              {
+                "id": "displayName",
+                "value": "dst RSE"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.dst-url"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 124
+              },
+              {
+                "id": "displayName",
+                "value": "dst URL"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.protocol"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 74
+              },
+              {
+                "id": "displayName",
+                "value": "Protocol"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.duration"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Duration"
+              },
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.reason"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Reason"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.src-rse"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "src RSE"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.src-url"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "src URL"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.started_at"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Started at"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.submitted_at"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Submitted at"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transfer-endpoint"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FTS"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transfer-id"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FTS ID"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transfer_link"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "FTS log link"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "payload.transferred_at"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Transferred at"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Transferred at"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 153
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 71
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 19,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+    "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "metrics": [
+            {
+              "id": "1",
+              "settings": {
+                "order": "desc",
+                "size": "500",
+                "useTimeRange": true
+              },
+              "type": "raw_data"
+            }
+          ],
+          "query": "event_type:transfer-submission_failed",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Transfer Submission Failure information",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "_id": true,
+              "_index": true,
+              "_source": true,
+              "_type": true,
+              "created_at": false,
+              "event_type": true,
+              "highlight": true,
+              "id": true,
+              "payload.bytes": true,
+              "payload.checksum-adler": true,
+              "payload.checksum-md5": true,
+              "payload.created_at": true,
+              "payload.datatype": true,
+              "payload.dst-rse": false,
+              "payload.dst-type": true,
+              "payload.file-size": true,
+              "payload.guid": true,
+              "payload.previous-request-id": true,
+              "payload.request-id": true,
+              "payload.scope": true,
+              "payload.src-type": true,
+              "payload.started_at": false,
+              "payload.tool-id": true,
+              "payload.transfer-endpoint": false,
+              "payload.transfer-link": true,
+              "services": true,
+              "sort": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ],
+      "transparent": true,
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Transfer-submitted",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "elasticsearch",
+        "uid": "${elasticsearch}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "$group_by",
+              "id": "2",
+              "settings": {
+                "min_doc_count": "1",
+                "order": "desc",
+                "orderBy": "_term",
+                "size": "10"
+              },
+              "type": "terms"
+            },
+            {
+              "field": "created_at",
+              "id": "3",
+              "settings": {
+                "interval": "$bin",
+                "min_doc_count": "0",
+                "timeZone": "utc",
+                "trimEdges": "0"
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "datasource": {
+            "type": "elasticsearch",
+            "uid": "${elasticsearch}"
+          },
+          "metrics": [
+            {
+              "field": "payload.bytes",
+              "id": "1",
+              "type": "sum"
+            }
+          ],
+          "query": "event_type:transfer-done AND payload.dst-rse:${dst_rse:lucene} AND payload.src-rse:${src_rse:lucene} AND payload.protocol:${protocol:lucene} AND payload.transfer-endpoint:${fts:lucene}",
+          "refId": "A",
+          "timeField": "created_at"
+        }
+      ],
+      "title": "Transfer-submitted by $group_by",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "${elasticsearch}"
+        },
+        "definition": "{\"find\": \"terms\", \"field\": \"payload.transfer-endpoint\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "FTS Server",
+        "multi": true,
+        "name": "fts",
+        "options": [],
+        "query": "{\"find\": \"terms\", \"field\": \"payload.transfer-endpoint\"}",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "${elasticsearch}"
+        },
+        "definition": "{\"find\":  \"terms\", \"field\": \"payload.dst-rse\"} ",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Dest Site",
+        "multi": true,
+        "name": "dst_rse",
+        "options": [],
+        "query": "{\"find\":  \"terms\", \"field\": \"payload.dst-rse\"} ",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "${elasticsearch}"
+        },
+        "definition": "{\"find\":  \"terms\", \"field\": \"payload.src-rse\"} ",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Source Site",
+        "multi": true,
+        "name": "src_rse",
+        "options": [],
+        "query": "{\"find\":  \"terms\", \"field\": \"payload.src-rse\"} ",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "payload.dst-rse",
+          "value": "payload.dst-rse"
+        },
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "${elasticsearch}"
+        },
+        "definition": "{\"find\": \"fields\", \"type\": \"keyword\"}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Group By",
+        "multi": false,
+        "name": "group_by",
+        "options": [],
+        "query": "{\"find\": \"fields\", \"type\": \"keyword\"}",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "${elasticsearch}"
+        },
+        "definition": "{\"find\": \"terms\", \"field\": \"payload.protocol\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Protocol",
+        "multi": true,
+        "name": "protocol",
+        "options": [],
+        "query": "{\"find\": \"terms\", \"field\": \"payload.protocol\"}",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "${elasticsearch}"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filters",
+        "name": "filters",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      },
+      {
+        "auto": true,
+        "auto_count": 20,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "1h",
+          "value": "1h"
+        },
+        "hide": 0,
+        "label": "Bin",
+        "name": "bin",
+        "options": [
+          {
             "selected": false,
+            "text": "auto",
+            "value": "$__auto_interval_bin"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": true,
             "text": "1h",
             "value": "1h"
           },
-          "hide": 0,
-          "label": "Bin",
-          "name": "bin",
-          "options": [
-            {
-              "selected": false,
-              "text": "auto",
-              "value": "$__auto_interval_bin"
-            },
-            {
-              "selected": false,
-              "text": "1m",
-              "value": "1m"
-            },
-            {
-              "selected": false,
-              "text": "10m",
-              "value": "10m"
-            },
-            {
-              "selected": false,
-              "text": "30m",
-              "value": "30m"
-            },
-            {
-              "selected": true,
-              "text": "1h",
-              "value": "1h"
-            },
-            {
-              "selected": false,
-              "text": "6h",
-              "value": "6h"
-            },
-            {
-              "selected": false,
-              "text": "12h",
-              "value": "12h"
-            },
-            {
-              "selected": false,
-              "text": "1d",
-              "value": "1d"
-            },
-            {
-              "selected": false,
-              "text": "7d",
-              "value": "7d"
-            },
-            {
-              "selected": false,
-              "text": "14d",
-              "value": "14d"
-            },
-            {
-              "selected": false,
-              "text": "30d",
-              "value": "30d"
-            }
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "queryValue": "",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
           ],
-          "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
-          "queryValue": "",
-          "refresh": 2,
-          "skipUrlSync": false,
-          "type": "interval"
+          "value": [
+            "$__all"
+          ]
         },
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
-            ]
-          },
-          "datasource": {
-            "type": "elasticsearch",
-            "uid": "${elasticsearch}"
-          },
-          "definition": "{\"find\": \"terms\", \"field\": \"payload.rse\"}",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Deletion RSE",
-          "multi": true,
-          "name": "del_rse",
-          "options": [],
-          "query": "{\"find\": \"terms\", \"field\": \"payload.rse\"}",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        }
-      ]
-    },
-    "time": {
-      "from": "now-7d",
-      "to": "now-0m"
-    },
-    "timepicker": {
-      "nowDelay": "0m"
-    },
-    "timezone": "",
-    "title": "Rucio Transfer",
-    "uid": "APINeRt1Pufgf",
-    "version": 41,
-    "weekStart": ""
-  }
+        "datasource": {
+          "type": "elasticsearch",
+          "uid": "${elasticsearch}"
+        },
+        "definition": "{\"find\": \"terms\", \"field\": \"payload.rse\"}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Deletion RSE",
+        "multi": true,
+        "name": "del_rse",
+        "options": [],
+        "query": "{\"find\": \"terms\", \"field\": \"payload.rse\"}",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now-0m"
+  },
+  "timepicker": {
+    "nowDelay": "0m"
+  },
+  "timezone": "",
+  "title": "Rucio Transfer",
+  "version": 41,
+  "weekStart": ""
+ }
 }

--- a/message-monitoring/ElasticSearch/rucio-events
+++ b/message-monitoring/ElasticSearch/rucio-events
@@ -15,110 +15,42 @@
     "aliases" : { },
     "mappings" : {
       "properties" : {
-        "created_at" : {
-          "type" : "date"
-        },
-        "event_type" : {
-          "type" : "keyword"
-        },
-        "id" : {
-          "type" : "keyword"
-        },
+        "created_at" : {"type" : "date"},
+        "event_type" : {"type" : "keyword"},
+        "id" : {"type" : "keyword"},
         "payload" : {
           "properties" : {
-            "activity" : {
-              "type" : "keyword"
-            },
-            "bytes" : {
-              "type" : "long"
-            },
-            "checksum-adler" : {
-              "type" : "keyword"
-            },
-            "checksum-md5" : {
-              "type" : "keyword"
-            },
-            "created_at" : {
-              "type" : "date"
-            },
-            "dataset" : {
-              "type" : "keyword"
-            },
-            "datasetScope" : {
-              "type" : "keyword"
-            },
-            "dst-rse" : {
-              "type" : "keyword"
-            },
-            "dst-type" : {
-              "type" : "keyword"
-            },
-            "dst-url" : {
-              "type" : "keyword"
-            },
-            "duration" : {
-              "type" : "float"
-            },
-            "file-size" : {
-              "type" : "long"
-            },
-            "name" : {
-              "type" : "keyword"
-            },
-            "previous-request-id" : {
-              "type" : "keyword"
-            },
-            "protocol" : {
-              "type" : "keyword"
-            },
-            "reason" : {
-              "type" : "keyword"
-            },
-            "rse" : {
-              "type" : "keyword"
-            },
-            "request-id" : {
-              "type" : "keyword"
-            },
-            "scope" : {
-              "type" : "keyword"
-            },
-            "src-rse" : {
-              "type" : "keyword"
-            },
-            "src-type" : {
-              "type" : "keyword"
-            },
-            "src-url" : {
-              "type" : "keyword"
-            },
-            "started_at" : {
-              "type" : "date"
-            },
-            "submitted_at" : {
-              "type" : "date"
-            },
-            "tool-id" : {
-              "type" : "keyword"
-            },
-            "transfer-endpoint" : {
-              "type" : "keyword"
-            },
-            "transfer-id" : {
-              "type" : "keyword"
-            },
-            "transfer_link" : {
-              "type" : "keyword"
-            },
-            "transferred_at" : {
-              "type" : "date"
-            },
-            "url" : {
-              "type" : "keyword"
-            },
-            "vo" : {
-              "type" : "keyword"
-            }
+            "activity" : {"type" : "keyword"},
+            "bytes" : {"type" : "long"},
+            "checksum-adler" : {"type" : "keyword"},
+            "checksum-md5" : {"type" : "keyword"},
+            "created_at" : {"type" : "keyword"},
+            "dataset" : {"type" : "keyword"},
+            "datasetScope" : {"type" : "keyword"},
+            "dst-rse" : {"type" : "keyword"},
+            "dst-type" : {"type" : "keyword"},
+            "dst-url" : {"type" : "keyword"},
+            "duration" : {"type" : "float"},
+            "file-size" : {"type" : "long"},
+            "name" : {"type" : "keyword"},
+            "previous-request-id" : {"type" : "keyword"},
+            "protocol" : {"type" : "keyword"},
+            "reason" : {"type" : "keyword"},
+            "rse" : {"type" : "keyword"},
+            "request-id" : {"type" : "keyword"},
+            "scope" : {"type" : "keyword"},
+            "src-rse" : {"type" : "keyword"},
+            "src-type" : {"type" : "keyword"},
+            "src-url" : {"type" : "keyword"},
+            "started_at" : {"type" : "keyword"},
+            "submitted_at" : {"type" : "keyword"},
+            "tool-id" : {"type" : "keyword"},
+            "transfer-endpoint" : {"type" : "keyword"},
+            "transfer-id" : {"type" : "keyword"},
+            "transfer_link" : {"type" : "keyword"},
+            "transferred_at" : {"type" : "keyword"},
+            "url" : {"type" : "keyword"},
+            "vo" : {"type" : "keyword"}
           }
         },
         "services" : {

--- a/prometheus-monitoring/Dashboards/Rucio-Internal.json
+++ b/prometheus-monitoring/Dashboards/Rucio-Internal.json
@@ -39,11 +39,11 @@
       }
     ]
   },
-  "description": "",
   "editable": true,
+  "description": "",
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": null,
   "interval": "$bin",
   "links": [],
   "liveNow": false,
@@ -1826,7 +1826,6 @@
   },
   "timezone": "browser",
   "title": "Rucio Internal Services",
-  "uid": "null",
   "version": 16,
   "weekStart": "monday"
  }

--- a/prometheus-monitoring/Dashboards/Rucio-Internal.json
+++ b/prometheus-monitoring/Dashboards/Rucio-Internal.json
@@ -1256,7 +1256,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(increase(rest_client_requests_total[$bin]))",
+          "expr": "sum(increase(rucio_core_request_get_and_mark_next_count[$bin]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "{{label_name}}",


### PR DESCRIPTION
fixing the transfer dashboard and the rucio-events file, that did not work with elasticsearch: `("elasticsearch.node.name":"eck-elasticsearch-es-worker-0","elasticsearch.cluster.name":"eck-elasticsearch","tags":["[rucio-events]"],"error.type":"org.elasticsearch.index.mapper.DocumentParsingException","error.message":"[1:947] failed to parse field [payload.created_at] of type [date] in document with id '1qUep5oBrmsEhYW5LY3Z'. Preview of field's value: '2025-11-21 15:51:26.497213'")`